### PR TITLE
feat (BREAKING): add interpreter settings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+### Go template
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ func readPdf(path string) (string, error) {
 		return "", err
 	}
 	var buf bytes.Buffer
-    b, err := r.GetPlainText()
+    b, err := r.GetPlainText(pdf.NewInterpreter())
     if err != nil {
         return "", err
     }
@@ -68,7 +68,7 @@ func readPdf2(path string) (string, error) {
 			continue
 		}
 		var lastTextStyle pdf.Text
-		texts := p.Content().Text
+		texts := p.Content(pdf.NewInterpreter()).Text
 		for _, text := range texts {
 			if isSameSentence(text, lastTextStyle) {
 				lastTextStyle.S = lastTextStyle.S + text.S
@@ -120,7 +120,7 @@ func readPdf(path string) (string, error) {
 			continue
 		}
 
-		rows, _ := p.GetTextByRow()
+		rows, _ := p.GetTextByRow(pdf.NewInterpreter())
 		for _, row := range rows {
 		    println(">>>> row: ", row.Position)
 		    for _, word := range row.Content {

--- a/ascii85.go
+++ b/ascii85.go
@@ -29,6 +29,7 @@ func checkASCII85(r byte) byte {
 func (a *alphaReader) Read(p []byte) (int, error) {
 	n, err := a.reader.Read(p)
 	if err == io.EOF {
+		return 0, nil
 	}
 	if err != nil {
 		return n, err

--- a/ps.go
+++ b/ps.go
@@ -7,6 +7,7 @@ package pdf
 import (
 	"fmt"
 	"io"
+	"slices"
 )
 
 // A Stack represents a stack of values.
@@ -37,6 +38,36 @@ func newDict() Value {
 	return Value{nil, objptr{}, make(dict)}
 }
 
+type InterpreterConfig struct {
+	IgnoreDefOfNonNameVals []string
+}
+
+type Interpreter struct {
+	Config InterpreterConfig
+}
+
+func defaultInterpreterConfig() InterpreterConfig {
+	return InterpreterConfig{
+		IgnoreDefOfNonNameVals: []string{},
+	}
+}
+
+func NewInterpreter(opts ...Option) *Interpreter {
+	config := defaultInterpreterConfig()
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return &Interpreter{Config: config}
+}
+
+type Option func(*InterpreterConfig)
+
+func WithIgnoreDefOfNonNameVals(vals []string) Option {
+	return func(c *InterpreterConfig) {
+		c.IgnoreDefOfNonNameVals = vals
+	}
+}
+
 // Interpret interprets the content in a stream as a basic PostScript program,
 // pushing values onto a stack and then calling the do function to execute
 // operators. The do function may push or pop values from the stack as needed
@@ -53,7 +84,7 @@ func newDict() Value {
 // In the case of a simple stream read only once, otherwise get the length of the stream to handle it properly
 //
 // There is no support for executable blocks, among other limitations.
-func Interpret(strm Value, do func(stk *Stack, op string)) {
+func (ip *Interpreter) Interpret(strm Value, do func(stk *Stack, op string)) {
 	var stk Stack
 	var dicts []dict
 	s := strm
@@ -122,9 +153,10 @@ func Interpret(strm Value, do func(stk *Stack, op string)) {
 					}
 					val := stk.Pop()
 					key, ok := stk.Pop().data.(name)
-					if !ok {
+					if !ok && (!slices.Contains(ip.Config.IgnoreDefOfNonNameVals, val.Name())) {
 						panic("def of non-name")
 					}
+
 					dicts[len(dicts)-1][key] = val.data
 					continue
 				case "pop":

--- a/read.go
+++ b/read.go
@@ -4,7 +4,7 @@
 
 // Package pdf implements reading of PDF files.
 //
-// Overview
+// # Overview
 //
 // PDF is Adobe's Portable Document Format, ubiquitous on the internet.
 // A PDF document is a complex data format built on a fairly simple structure.
@@ -43,7 +43,6 @@
 // they are implemented only in terms of the Value API and could be moved outside
 // the package. Equally important, traversal of other PDF data structures can be implemented
 // in other packages as needed.
-//
 package pdf
 
 // BUG(rsc): The package is incomplete, although it has been used successfully on some
@@ -70,7 +69,6 @@ import (
 	"encoding/ascii85"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -78,6 +76,8 @@ import (
 
 // DebugOn is responsible for logging messages into stdout. If problems arise during reading, set it true.
 var DebugOn = false
+
+var TraceOn = false
 
 // A Reader is a single PDF file open for reading.
 type Reader struct {
@@ -105,7 +105,9 @@ func (r *Reader) errorf(format string, args ...interface{}) {
 func Open(file string) (*os.File, *Reader, error) {
 	f, err := os.Open(file)
 	if err != nil {
-		f.Close()
+		if f != nil {
+			f.Close()
+		}
 		return nil, nil, err
 	}
 	fi, err := f.Stat()
@@ -611,7 +613,7 @@ func (v Value) RawString() string {
 	return x
 }
 
-// Text returns v's string value interpreted as a ``text string'' (defined in the PDF spec)
+// Text returns v's string value interpreted as a “text string” (defined in the PDF spec)
 // and converted to UTF-8.
 // If v.Kind() != String, Text returns the empty string.
 func (v Value) Text() string {
@@ -800,7 +802,7 @@ func (e *errorReadCloser) Close() error {
 
 // Reader returns the data contained in the stream v.
 // If v.Kind() != Stream, Reader returns a ReadCloser that
-// responds to all reads with a ``stream not present'' error.
+// responds to all reads with a “stream not present” error.
 func (v Value) Reader() io.ReadCloser {
 	x, ok := v.data.(stream)
 	if !ok {
@@ -826,7 +828,7 @@ func (v Value) Reader() io.ReadCloser {
 		}
 	}
 
-	return ioutil.NopCloser(rd)
+	return io.NopCloser(rd)
 }
 
 func applyFilter(rd io.Reader, name string, param Value) io.Reader {


### PR DESCRIPTION
- New Interpreter Options, e.g. to ignore some Postscript interpretation errors (e.g. ignore "def of non-name" for malformed PDFs where CMapName is set incorrectly, which doesn't stop text extraction)